### PR TITLE
Split GSETTINGS_SCHEMA_DIR using G_SEARCHPATH_SEPARATOR_S

### DIFF
--- a/lib/src/gsettings.dart
+++ b/lib/src/gsettings.dart
@@ -242,7 +242,7 @@ List<Directory> _getSchemaDirs() {
 
   var schemaDir = Platform.environment['GSETTINGS_SCHEMA_DIR'];
   if (schemaDir != null) {
-    schemaDirs.add(Directory(schemaDir));
+    schemaDirs.addAll(schemaDir.split(':').map((path) => Directory(path)));
   }
 
   for (var dataDir in dataDirs) {


### PR DESCRIPTION
> This variable can be set to the names of directories to consider when looking for compiled schemas for GSettings, in addition to the `glib-2.0/schemas` subdirectories of the XDG system data dirs. To specify multiple directories, use `G_SEARCHPATH_SEPARATOR_S` as a separator.

https://docs.gtk.org/gio/overview.html