### PR TITLE
chore: bump dependency xdg_directories to ^1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ platforms:
 
 dependencies:
   dbus: ^0.7.8
-  xdg_directories: ^0.2.0
+  xdg_directories: ^1.0.0
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
There are no major changes - it's just considered stable now.

> Updates version to 1.0 to reflect the level of API stability.

https://pub.dev/packages/xdg_directories/changelog