### PR TITLE
Fix error

### DIFF
--- a/lib/src/dconf_client.dart
+++ b/lib/src/dconf_client.dart
@@ -210,7 +210,7 @@ class DConfClient {
         case 'service-db': // Not implemented
         case 'file-db': // Not implemented
         default:
-          throw "Unknown DConf source: 'line'";
+          throw "Unknown DConf source: '$line'";
       }
       sources.add(source);
     }


### PR DESCRIPTION
Fixes the error when an unknown dconf source is used, to actually print out the line rather than just 'line'.